### PR TITLE
[MTG-482] using the delegated stake in the minimal requirement check

### DIFF
--- a/programs/bubblegum/Cargo.lock
+++ b/programs/bubblegum/Cargo.lock
@@ -2590,8 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-token-auth-rules"
-version = "1.5.0"
-source = "git+https://github.com/metaplex-foundation/mpl-token-auth-rules.git?branch=main#fd9026d68ebc7e1bc2aeb7af73d04e8161eeeaf8"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8637dd3d13d045a43a2410dbb57f0257d506838aa71461faf0eaf2806e6d5071"
 dependencies = [
  "borsh 0.10.3",
  "bytemuck",

--- a/programs/bubblegum/Cargo.lock
+++ b/programs/bubblegum/Cargo.lock
@@ -1014,13 +1014,14 @@ dependencies = [
  "bytemuck",
  "mpl-token-auth-rules",
  "mpl-token-metadata",
+ "mplx-rewards",
  "mplx-staking-states",
  "num-traits",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-account-compression",
- "spl-associated-token-account 1.1.3",
+ "spl-associated-token-account 2.3.0",
  "spl-concurrent-merkle-tree",
  "spl-merkle-tree-reference",
  "spl-noop",
@@ -2334,6 +2335,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lib-sokoban"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0640eb476052d9f48e920969f8117b054d1be1a0b2e4055e61293cd2b1afcce1"
+dependencies = [
+ "bytemuck",
+ "num-derive 0.3.3",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,7 +2600,7 @@ dependencies = [
  "num-traits",
  "rmp-serde",
  "serde",
- "shank",
+ "shank 0.3.0",
  "solana-program",
  "solana-zk-token-sdk",
  "thiserror",
@@ -2614,6 +2627,21 @@ checksum = "12989bc45715b0ee91944855130131479f9c772e198a910c3eb0ea327d5bffc3"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "mplx-rewards"
+version = "0.1.0"
+dependencies = [
+ "borsh 1.5.0",
+ "bytemuck",
+ "lib-sokoban",
+ "num-derive 0.4.2",
+ "num-traits",
+ "shank 0.4.2",
+ "solana-program",
+ "spl-token 4.0.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -2833,7 +2861,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.63",
@@ -3862,7 +3890,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c9395612d493b69a522725eef78a095f199d43eeb847f4a4b77ec0cacab535"
 dependencies = [
- "shank_macro",
+ "shank_macro 0.3.0",
+]
+
+[[package]]
+name = "shank"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d894855493d4ce613b25550fe1ed1c62d0af5486b984579ba55e3f8c9631d5"
+dependencies = [
+ "shank_macro 0.4.2",
 ]
 
 [[package]]
@@ -3873,8 +3910,21 @@ checksum = "8abef069c02e15f62233679b1e71f3152fac10f90b3ff89ebbad6a25b7497754"
 dependencies = [
  "proc-macro2",
  "quote",
- "shank_macro_impl",
- "shank_render",
+ "shank_macro_impl 0.3.0",
+ "shank_render 0.3.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "shank_macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bf2645f8eebde043da69200195058e7b59806705104f908a31d05ca82844ce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "shank_macro_impl 0.4.2",
+ "shank_render 0.4.2",
  "syn 1.0.109",
 ]
 
@@ -3892,6 +3942,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shank_macro_impl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d0593f48acb0a722906416b1f6b8926f6571eb9af16d566a7c65427f269f50"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "shank_render"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,7 +3962,18 @@ checksum = "5a2ea9c6dd95ea311b3b81e63cf4e9c808ed04b098819e6d2c4b1a467d587203"
 dependencies = [
  "proc-macro2",
  "quote",
- "shank_macro_impl",
+ "shank_macro_impl 0.3.0",
+]
+
+[[package]]
+name = "shank_render"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121175ba61809189f888dc5822ebfd30fa0d91e1e1f61d25a4d40b0847b3075e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "shank_macro_impl 0.4.2",
 ]
 
 [[package]]

--- a/programs/bubblegum/Cargo.lock
+++ b/programs/bubblegum/Cargo.lock
@@ -1025,7 +1025,7 @@ dependencies = [
  "spl-concurrent-merkle-tree",
  "spl-merkle-tree-reference",
  "spl-noop",
- "spl-token 3.5.0",
+ "spl-token 4.0.0",
 ]
 
 [[package]]
@@ -2632,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "mplx-rewards"
 version = "0.1.0"
-source = "git+https://github.com/adm-metaex/mplx-rewards.git?branch=mtg-464-prealloc#7eb7cc3ecbb03ae5ebdc1349c97ad9ad02e97f97"
+source = "git+https://github.com/adm-metaex/mplx-rewards.git#406078fcc3656dfeb57ae776ee81097480a27a62"
 dependencies = [
  "borsh 1.5.0",
  "bytemuck",
@@ -2648,14 +2648,11 @@ dependencies = [
 [[package]]
 name = "mplx-staking-states"
 version = "0.0.1"
-source = "git+https://github.com/adm-metaex/mplx-staking.git#094f7277c4c7d1a0549415df1b152cc0c525a1c7"
+source = "git+https://github.com/adm-metaex/mplx-staking.git#03459b9290d3fe58b5788728b434a6441adc1779"
 dependencies = [
  "anchor-lang 0.26.0",
  "anchor-spl 0.26.0",
- "borsh 0.9.3",
- "bytemuck",
  "static_assertions",
- "thiserror",
 ]
 
 [[package]]

--- a/programs/bubblegum/Cargo.lock
+++ b/programs/bubblegum/Cargo.lock
@@ -2632,6 +2632,7 @@ dependencies = [
 [[package]]
 name = "mplx-rewards"
 version = "0.1.0"
+source = "git+https://github.com/adm-metaex/mplx-rewards.git?branch=mtg-464-prealloc#7eb7cc3ecbb03ae5ebdc1349c97ad9ad02e97f97"
 dependencies = [
  "borsh 1.5.0",
  "bytemuck",

--- a/programs/bubblegum/program/Cargo.toml
+++ b/programs/bubblegum/program/Cargo.toml
@@ -30,6 +30,7 @@ spl-account-compression = {git = "https://github.com/StanChe/solana-program-libr
 spl-associated-token-account = { version = ">= 1.1.3, < 3.0", features = ["no-entrypoint"] }
 spl-token = { version = ">= 3.5.0, < 5.0", features = ["no-entrypoint"] }
 mplx-staking-states = {git = "https://github.com/adm-metaex/mplx-staking.git" }
+mplx-rewards = {git = "https://github.com/adm-metaex/mplx-rewards.git", branch = "mtg-464-prealloc", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 async-trait = "0.1.71"

--- a/programs/bubblegum/program/Cargo.toml
+++ b/programs/bubblegum/program/Cargo.toml
@@ -29,8 +29,8 @@ solana-program = "~1.18.11"
 spl-account-compression = {git = "https://github.com/StanChe/solana-program-library.git", branch = "feature/init_with_root", features = ["cpi"] }
 spl-associated-token-account = { version = ">= 1.1.3, < 3.0", features = ["no-entrypoint"] }
 spl-token = { version = ">= 3.5.0, < 5.0", features = ["no-entrypoint"] }
-mplx-staking-states = {git = "https://github.com/adm-metaex/mplx-staking.git" }
-mplx-rewards = {git = "https://github.com/adm-metaex/mplx-rewards.git", branch = "mtg-464-prealloc", features = ["no-entrypoint"] }
+mplx-staking-states = { git = "https://github.com/adm-metaex/mplx-staking.git" }
+mplx-rewards = { git = "https://github.com/adm-metaex/mplx-rewards.git", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 async-trait = "0.1.71"

--- a/programs/bubblegum/program/Cargo.toml
+++ b/programs/bubblegum/program/Cargo.toml
@@ -34,7 +34,7 @@ mplx-rewards = { git = "https://github.com/adm-metaex/mplx-rewards.git", feature
 
 [dev-dependencies]
 async-trait = "0.1.71"
-mpl-token-auth-rules = { git = "https://github.com/metaplex-foundation/mpl-token-auth-rules.git", branch = "main", features = ["no-entrypoint"] }
+mpl-token-auth-rules = { version = "1.5.1", features = ["no-entrypoint"] }
 solana-program-test = "~1.18.11"
 solana-sdk = "~1.18.11"
 spl-concurrent-merkle-tree = { git = "https://github.com/StanChe/solana-program-library.git", branch = "feature/init_with_root" }

--- a/programs/bubblegum/program/src/error.rs
+++ b/programs/bubblegum/program/src/error.rs
@@ -106,6 +106,8 @@ pub enum BubblegumError {
     StakingVoterRegistrarMismatch,
     #[msg("Staking voter authority mismatch")]
     StakingVoterAuthorityMismatch,
+    #[msg("Invalid mining owner")]
+    MiningOwnerMismatch,
 }
 
 // Converts certain Token Metadata errors into Bubblegum equivalents

--- a/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
+++ b/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
@@ -177,7 +177,8 @@ pub(crate) fn check_stake<'info>(
         BubblegumError::StakingVoterDiscriminatorMismatch
     );
 
-    let voter: Voter = *bytemuck::from_bytes(&(*voter_bytes.borrow())[8..]);
+    let voter_bytes = Box::new(voter_bytes.borrow());
+    let voter: Box<&Voter> = Box::new(bytemuck::from_bytes(&voter_bytes[8..]));
 
     require!(
         &voter.registrar == registrar_acc.key,
@@ -188,8 +189,8 @@ pub(crate) fn check_stake<'info>(
         BubblegumError::StakingVoterAuthorityMismatch
     );
     // todo: use a non mutable version of the mining
-    let mut mining_data = mining_acc.data.borrow_mut();
-    let mining = mplx_rewards::state::WrappedMining::from_bytes_mut(&mut mining_data)?;
+    let mining_data = mining_acc.data.borrow();
+    let mining = mplx_rewards::state::WrappedImmutableMining::from_bytes(&mining_data)?;
     require!(
         &mining.mining.owner == staker_acc.key,
         BubblegumError::MiningOwnerMismatch

--- a/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
+++ b/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
@@ -179,8 +179,7 @@ pub(crate) fn check_stake<'info>(
         BubblegumError::StakingVoterDiscriminatorMismatch
     );
 
-    // The Voter has a rather big structure. If we try to deserialize it on the stack it will be overflowed. Therefore, Box is used to move bytes that have been borrowed to the Heap.
-    let voter_bytes = Box::new(voter_bytes.borrow());
+    let voter_bytes = voter_bytes.borrow();
     let voter: &Voter = bytemuck::from_bytes(&voter_bytes[DISCRIMINATOR_LEN..]);
 
     require!(

--- a/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
+++ b/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
@@ -177,8 +177,9 @@ pub(crate) fn check_stake<'info>(
         BubblegumError::StakingVoterDiscriminatorMismatch
     );
 
+    // The Voter has a rather big structure. If we try to deserialize it as other accounts it'll overflow the stack.
     let voter_bytes = Box::new(voter_bytes.borrow());
-    let voter: Box<&Voter> = Box::new(bytemuck::from_bytes(&voter_bytes[8..]));
+    let voter: &Voter = bytemuck::from_bytes(&voter_bytes[8..]);
 
     require!(
         &voter.registrar == registrar_acc.key,

--- a/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
+++ b/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
@@ -177,7 +177,7 @@ pub(crate) fn check_stake<'info>(
         BubblegumError::StakingVoterDiscriminatorMismatch
     );
 
-    // The Voter has a rather big structure. If we try to deserialize it as other accounts it'll overflow the stack.
+    // The Voter has a rather big structure. If we try to deserialize it on the stack it will be overflowed. Therefore, Box is used to move bytes that have been borrowed to the Heap.
     let voter_bytes = Box::new(voter_bytes.borrow());
     let voter: &Voter = bytemuck::from_bytes(&voter_bytes[8..]);
 

--- a/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
+++ b/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
@@ -188,7 +188,6 @@ pub(crate) fn check_stake<'info>(
         &voter.voter_authority == staker_acc.key,
         BubblegumError::StakingVoterAuthorityMismatch
     );
-    // todo: use a non mutable version of the mining
     let mining_data = mining_acc.data.borrow();
     let mining = mplx_rewards::state::WrappedImmutableMining::from_bytes(&mining_data)?;
     require!(

--- a/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
+++ b/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
@@ -155,14 +155,13 @@ pub(crate) fn check_stake<'info>(
     );
 
     let registrar_bytes = registrar_acc.to_account_info().data;
-
+    let registrar_bytes = registrar_bytes.borrow();
     require!(
-        (*registrar_bytes.borrow())[..DISCRIMINATOR_LEN] == REGISTRAR_DISCRIMINATOR,
+        registrar_bytes[..DISCRIMINATOR_LEN] == REGISTRAR_DISCRIMINATOR,
         BubblegumError::StakingRegistrarDiscriminatorMismatch
     );
 
-    let registrar: Registrar =
-        *bytemuck::from_bytes(&(*registrar_bytes.borrow())[DISCRIMINATOR_LEN..]);
+    let registrar: &Registrar = bytemuck::from_bytes(&registrar_bytes[DISCRIMINATOR_LEN..]);
 
     require!(
         registrar.realm == REALM,

--- a/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
+++ b/programs/bubblegum/program/src/processor/finalize_tree_with_root.rs
@@ -174,12 +174,11 @@ pub(crate) fn check_stake<'info>(
     );
     let voter_bytes = voter_acc.to_account_info().data;
 
+    let voter_bytes = voter_bytes.borrow();
     require!(
-        (*voter_bytes.borrow())[..DISCRIMINATOR_LEN] == VOTER_DISCRIMINATOR,
+        voter_bytes[..DISCRIMINATOR_LEN] == VOTER_DISCRIMINATOR,
         BubblegumError::StakingVoterDiscriminatorMismatch
     );
-
-    let voter_bytes = voter_bytes.borrow();
     let voter: &Voter = bytemuck::from_bytes(&voter_bytes[DISCRIMINATOR_LEN..]);
 
     require!(

--- a/programs/bubblegum/program/src/processor/finalize_tree_with_root_and_collection.rs
+++ b/programs/bubblegum/program/src/processor/finalize_tree_with_root_and_collection.rs
@@ -27,6 +27,8 @@ pub struct FinalizeTreeWithRootAndCollection<'info> {
     /// CHECK:
     pub voter: UncheckedAccount<'info>,
     /// CHECK:
+    pub mining: UncheckedAccount<'info>,
+    /// CHECK:
     #[account(mut)]
     pub fee_receiver: UncheckedAccount<'info>,
     /// CHECK: Optional collection authority record PDA.
@@ -95,6 +97,7 @@ impl<'info> From<&mut FinalizeTreeWithRootAndCollection<'info>> for FinalizeTree
             staker: value.staker.to_owned(),
             registrar: value.registrar.to_owned(),
             voter: value.voter.to_owned(),
+            mining: value.mining.to_owned(),
             fee_receiver: value.fee_receiver.to_owned(),
             log_wrapper: value.log_wrapper.to_owned(),
             compression_program: value.compression_program.to_owned(),

--- a/programs/bubblegum/program/tests/batch-mint.rs
+++ b/programs/bubblegum/program/tests/batch-mint.rs
@@ -8,11 +8,12 @@ use bubblegum::{
     state::{
         metaplex_adapter::{MetadataArgs, TokenProgramVersion, TokenStandard},
         FEE_RECEIVER, PROTOCOL_FEE_PER_1024_ASSETS, REALM, REALM_GOVERNING_MINT,
+        VOTER_DISCRIMINATOR,
     },
 };
 use mplx_staking_states::state::{
     DepositEntry, Lockup, LockupKind, LockupPeriod, Registrar, Voter, VotingMintConfig,
-    REGISTRAR_DISCRIMINATOR, VOTER_DISCRIMINATOR,
+    REGISTRAR_DISCRIMINATOR,
 };
 use solana_program_test::{tokio, BanksClientError};
 use solana_sdk::{
@@ -152,6 +153,7 @@ async fn initialize_staking_accounts(
     let mplx_mint_key = Pubkey::new_unique();
     let grant_authority = Pubkey::new_unique();
     let mining_key = Pubkey::new_unique();
+    let reward_pool_key = Pubkey::new_unique();
 
     let registrar_key = Pubkey::find_program_address(
         &[
@@ -176,11 +178,6 @@ async fn initialize_staking_accounts(
     let voting_mint_config = VotingMintConfig {
         mint: mplx_mint_key,
         grant_authority,
-        baseline_vote_weight_scaled_factor: 0,
-        max_extra_lockup_vote_weight_scaled_factor: 0,
-        lockup_saturation_secs: 0,
-        digit_shift: 0,
-        padding: [0, 0, 0, 0, 0, 0, 0],
     };
 
     let registrar = Registrar {
@@ -188,14 +185,10 @@ async fn initialize_staking_accounts(
         realm: REALM,
         realm_governing_token_mint: REALM_GOVERNING_MINT,
         realm_authority: realm_authority.clone(),
-        voting_mints: [
-            voting_mint_config,
-            voting_mint_config,
-            voting_mint_config,
-            voting_mint_config,
-        ],
-        time_offset: 0,
+        voting_mints: [voting_mint_config, voting_mint_config],
+        reward_pool: reward_pool_key,
         bump: 0,
+        padding: [0; 7],
     };
 
     let current_time = SystemTime::now()
@@ -210,6 +203,7 @@ async fn initialize_staking_accounts(
         cooldown_requested: false,
         kind: LockupKind::Constant,
         period: LockupPeriod::ThreeMonths,
+        _reserved0: [0; 16],
         _reserved1: [0; 5],
     };
 
@@ -218,6 +212,9 @@ async fn initialize_staking_accounts(
         amount_deposited_native: 100_000_000_000_000,
         voting_mint_config_idx: 0,
         is_used: true,
+        delegate: Pubkey::new_unique(),
+        delegate_last_update_ts: 0,
+        _reserved0: [0; 32],
         _reserved1: [0; 6],
     };
 

--- a/programs/bubblegum/program/tests/batch-mint.rs
+++ b/programs/bubblegum/program/tests/batch-mint.rs
@@ -254,7 +254,7 @@ async fn initialize_staking_accounts(
     );
     voter_account.set_data_from_slice(voter_acc_data.as_ref());
     let mut mining_acc_data = [0; mplx_rewards::state::WrappedMining::LEN];
-    // TODO: good luck trying to make it work with those allignments requirements of the WrappedMining struct,
+    // TODO: good luck trying to make it work with those allignment requirements of the WrappedMining struct,
     // let account_type:u8 = mplx_rewards::state::AccountType::Mining.into();
     // mining_acc_data[0] = account_type;
     // let mining_acc = mplx_rewards::state::WrappedMining::from_bytes_mut(&mut mining_acc_data)

--- a/programs/bubblegum/program/tests/utils/tree.rs
+++ b/programs/bubblegum/program/tests/utils/tree.rs
@@ -287,6 +287,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> Tree<MAX_DEPTH, MAX_B
         metadata_hash: String,
         registrar: Pubkey,
         voter: Pubkey,
+        mining: Pubkey,
         fee_receiver: Pubkey,
     ) -> FinalizeWithRootBuilder<MAX_DEPTH, MAX_BUFFER_SIZE> {
         let tree_authority =
@@ -300,6 +301,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> Tree<MAX_DEPTH, MAX_B
             payer: payer.pubkey(),
             registrar,
             voter,
+            mining,
             fee_receiver,
             log_wrapper: spl_noop::id(),
             compression_program: spl_account_compression::id(),
@@ -337,6 +339,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> Tree<MAX_DEPTH, MAX_B
         metadata_hash: String,
         registrar: Pubkey,
         voter: Pubkey,
+        mining: Pubkey,
         fee_receiver: Pubkey,
     ) -> FinalizeWithRootAndCollectionBuilder<MAX_DEPTH, MAX_BUFFER_SIZE> {
         let tree_authority =
@@ -350,6 +353,7 @@ impl<const MAX_DEPTH: usize, const MAX_BUFFER_SIZE: usize> Tree<MAX_DEPTH, MAX_B
             payer: payer.pubkey(),
             registrar,
             voter,
+            mining,
             collection_authority: collection_authority.pubkey(),
             collection_authority_record_pda: bubblegum::id(),
             collection_mint: collection.mint.pubkey(),


### PR DESCRIPTION
For this to work the `mtg-464-prealloc` on the rewards needs to be updated to include no-entrypoint feature.